### PR TITLE
fix: complete font path fixes for all PDF generators

### DIFF
--- a/src/lib/utils/fontToBase64.ts
+++ b/src/lib/utils/fontToBase64.ts
@@ -39,10 +39,11 @@ export async function registerJapaneseFonts(pdf: import('jspdf').jsPDF): Promise
     // GitHub Pages対応の動的フォントパス取得
     const getFontBasePath = () => {
       if (typeof window === 'undefined') return '/fonts/'; // SSR
-      
-      const isGitHubPages = window.location.hostname === 'shuji-bonji.github.io' || 
-                           window.location.pathname.startsWith('/fact-checklist/') ||
-                           window.location.origin.includes('github.io');
+
+      const isGitHubPages =
+        window.location.hostname === 'shuji-bonji.github.io' ||
+        window.location.pathname.startsWith('/fact-checklist/') ||
+        window.location.origin.includes('github.io');
       return isGitHubPages ? '/fact-checklist/fonts/' : '/fonts/';
     };
 

--- a/src/lib/utils/fontToBase64.ts
+++ b/src/lib/utils/fontToBase64.ts
@@ -36,8 +36,20 @@ export async function loadFontAsBase64(fontUrl: string): Promise<string | null> 
 
 export async function registerJapaneseFonts(pdf: import('jspdf').jsPDF): Promise<boolean> {
   try {
+    // GitHub Pages対応の動的フォントパス取得
+    const getFontBasePath = () => {
+      if (typeof window === 'undefined') return '/fonts/'; // SSR
+      
+      const isGitHubPages = window.location.hostname === 'shuji-bonji.github.io' || 
+                           window.location.pathname.startsWith('/fact-checklist/') ||
+                           window.location.origin.includes('github.io');
+      return isGitHubPages ? '/fact-checklist/fonts/' : '/fonts/';
+    };
+
+    const fontBasePath = getFontBasePath();
+
     // Noto Sans JP Regular
-    const regularBase64 = await loadFontAsBase64('/fonts/NotoSansJP-Regular.ttf');
+    const regularBase64 = await loadFontAsBase64(`${fontBasePath}NotoSansJP-Regular.ttf`);
     if (regularBase64) {
       pdf.addFileToVFS('NotoSansJP-Regular.ttf', regularBase64);
       pdf.addFont('NotoSansJP-Regular.ttf', 'NotoSansJP', 'normal');
@@ -45,7 +57,7 @@ export async function registerJapaneseFonts(pdf: import('jspdf').jsPDF): Promise
     }
 
     // Noto Sans JP Bold
-    const boldBase64 = await loadFontAsBase64('/fonts/NotoSansJP-Bold.ttf');
+    const boldBase64 = await loadFontAsBase64(`${fontBasePath}NotoSansJP-Bold.ttf`);
     if (boldBase64) {
       pdf.addFileToVFS('NotoSansJP-Bold.ttf', boldBase64);
       pdf.addFont('NotoSansJP-Bold.ttf', 'NotoSansJP', 'bold');

--- a/src/lib/utils/japaneseFont.ts
+++ b/src/lib/utils/japaneseFont.ts
@@ -134,10 +134,22 @@ export async function addJapaneseFontToPDF(
  */
 export async function loadLocalJapaneseFont(pdf: jsPDF): Promise<string> {
   try {
+    // GitHub Pages対応の動的フォントパス取得
+    const getFontBasePath = () => {
+      if (typeof window === 'undefined') return '/fonts/'; // SSR
+      
+      const isGitHubPages = window.location.hostname === 'shuji-bonji.github.io' || 
+                           window.location.pathname.startsWith('/fact-checklist/') ||
+                           window.location.origin.includes('github.io');
+      return isGitHubPages ? '/fact-checklist/fonts/' : '/fonts/';
+    };
+    
+    const fontPath = `${getFontBasePath()}NotoSansJP-Regular.ttf`;
+    
     // 静的ファイルから読み込み
-    const response = await fetch('/fonts/NotoSansJP-Regular.ttf');
+    const response = await fetch(fontPath);
     if (!response.ok) {
-      throw new Error('ローカルフォント読み込み失敗');
+      throw new Error(`ローカルフォント読み込み失敗: ${fontPath}`);
     }
 
     const fontBuffer = await response.arrayBuffer();

--- a/src/lib/utils/japaneseFont.ts
+++ b/src/lib/utils/japaneseFont.ts
@@ -137,15 +137,16 @@ export async function loadLocalJapaneseFont(pdf: jsPDF): Promise<string> {
     // GitHub Pages対応の動的フォントパス取得
     const getFontBasePath = () => {
       if (typeof window === 'undefined') return '/fonts/'; // SSR
-      
-      const isGitHubPages = window.location.hostname === 'shuji-bonji.github.io' || 
-                           window.location.pathname.startsWith('/fact-checklist/') ||
-                           window.location.origin.includes('github.io');
+
+      const isGitHubPages =
+        window.location.hostname === 'shuji-bonji.github.io' ||
+        window.location.pathname.startsWith('/fact-checklist/') ||
+        window.location.origin.includes('github.io');
       return isGitHubPages ? '/fact-checklist/fonts/' : '/fonts/';
     };
-    
+
     const fontPath = `${getFontBasePath()}NotoSansJP-Regular.ttf`;
-    
+
     // 静的ファイルから読み込み
     const response = await fetch(fontPath);
     if (!response.ok) {

--- a/src/lib/utils/textBasedPDFGenerator.ts
+++ b/src/lib/utils/textBasedPDFGenerator.ts
@@ -390,7 +390,7 @@ export class TextBasedPDFGenerator {
     try {
       // GitHub Pages対応の動的フォントパス取得
       const fontBasePath = getFontBasePath();
-      
+
       // NotoSansJPフォントを読み込み
       const fontBase64 = await loadFontAsBase64(`${fontBasePath}NotoSansJP-Regular.ttf`);
       if (fontBase64) {

--- a/src/lib/utils/textBasedPDFGenerator.ts
+++ b/src/lib/utils/textBasedPDFGenerator.ts
@@ -7,7 +7,7 @@
 import type jsPDF from 'jspdf';
 import type { ChecklistResult, CheckItem, CheckCategory } from '$lib/types/checklist.js';
 import { getCategories } from '$lib/data/checklist-items.js';
-import { loadFontAsBase64 } from '$lib/i18n/fonts.js';
+import { loadFontAsBase64, getFontBasePath } from '$lib/i18n/fonts.js';
 import type { TranslationFunction } from '$lib/types/i18n.js';
 
 export interface TextPDFOptions {
@@ -388,15 +388,18 @@ export class TextBasedPDFGenerator {
    */
   private async setupJapaneseFont(): Promise<void> {
     try {
+      // GitHub Pages対応の動的フォントパス取得
+      const fontBasePath = getFontBasePath();
+      
       // NotoSansJPフォントを読み込み
-      const fontBase64 = await loadFontAsBase64('/fonts/NotoSansJP-Regular.ttf');
+      const fontBase64 = await loadFontAsBase64(`${fontBasePath}NotoSansJP-Regular.ttf`);
       if (fontBase64) {
         this.pdf.addFileToVFS('NotoSansJP-Regular.ttf', fontBase64);
         this.pdf.addFont('NotoSansJP-Regular.ttf', 'NotoSansJP', 'normal');
 
         // Boldフォントも試行
         try {
-          const boldFontBase64 = await loadFontAsBase64('/fonts/NotoSansJP-Bold.ttf');
+          const boldFontBase64 = await loadFontAsBase64(`${fontBasePath}NotoSansJP-Bold.ttf`);
           if (boldFontBase64) {
             this.pdf.addFileToVFS('NotoSansJP-Bold.ttf', boldFontBase64);
             this.pdf.addFont('NotoSansJP-Bold.ttf', 'NotoSansJP', 'bold');


### PR DESCRIPTION
close #89 

- Fix textBasedPDFGenerator.ts font path for GitHub Pages
- Fix japaneseFont.ts loadLocalJapaneseFont for GitHub Pages
- Fix fontToBase64.ts registerJapaneseFonts for GitHub Pages
- Add dynamic font path detection to all font loading functions
- Resolve 404 errors for all PDF export modes in production

All PDF export modes now correctly use:
- Production: /fact-checklist/fonts/NotoSansJP-Regular.ttf
- Development: /fonts/NotoSansJP-Regular.ttf

🤖 Generated with [Claude Code](https://claude.ai/code)