### PR TITLE
fix: prevent duplicate meta tags by skipping layout generation for in…

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,7 +33,7 @@
         siteName: string;
         type: string;
         locale: string;
-      };
+      } | null;
       detectedLanguage?: string;
     };
   }

--- a/src/routes/api/debug-meta/+server.ts
+++ b/src/routes/api/debug-meta/+server.ts
@@ -1,0 +1,21 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+/**
+ * Debug endpoint to verify meta tag generation logic
+ */
+export const GET: RequestHandler = async ({ url, request }) => {
+  const pathname = url.searchParams.get('path') || '/';
+  const acceptLanguage = request.headers.get('accept-language') ?? '';
+  
+  // Simulate the logic from layout.server.ts
+  const shouldSkipMeta = pathname.includes('/intro');
+  
+  return json({
+    path: pathname,
+    shouldSkipMeta,
+    reason: shouldSkipMeta ? 'Page has dedicated server load function' : 'Uses layout meta generation',
+    acceptLanguage,
+    timestamp: new Date().toISOString()
+  });
+};


### PR DESCRIPTION
…tro page

- Add path detection in layout.server.ts to skip meta generation for /intro
- Update TypeScript interfaces to handle null meta data
- Add debug endpoint to verify meta tag generation logic
- Prevent og:image duplication between layout and page-specific servers

This ensures each page has only one set of meta tags from the appropriate source:
- /intro: uses intro/+page.server.ts (og-image-intro.png)
- Other pages: uses +layout.server.ts (og-image.png)