### PR TITLE
fix: #129 状態保存のフロー変更

### DIFF
--- a/src/lib/components/HistorySidebar.svelte
+++ b/src/lib/components/HistorySidebar.svelte
@@ -30,8 +30,14 @@
   }
 
   async function createNewChecklist() {
-    const id = await refactoredChecklistStore.createNewChecklist();
-    goto(`${base}/?id=${id}`);
+    // sessionStorageをクリアして新規作成
+    const sessionService = (
+      await import('$lib/services/SessionStorageService')
+    ).SessionStorageService.getInstance();
+    sessionService.clearSession();
+
+    // UUIDなしでホームに移動（セッション一時IDで作成される）
+    goto(`${base}/`);
   }
 
   // 判定タイプに応じたアイコンとスタイル

--- a/src/lib/services/SessionStorageService.ts
+++ b/src/lib/services/SessionStorageService.ts
@@ -1,0 +1,144 @@
+/**
+ * SessionStorage管理サービス
+ * 一時的な編集状態の保持に使用
+ */
+
+import type { ChecklistResult, CheckItem, JudgmentType } from '$lib/types/checklist';
+import type { LanguageCode } from '$lib/i18n/types';
+
+interface SessionData {
+  title: string;
+  description: string;
+  notes: string;
+  items: CheckItem[];
+  judgment: JudgmentType;
+  language?: LanguageCode;
+  lastUpdated: string;
+}
+
+const SESSION_KEY = 'fact-checklist-session';
+
+export class SessionStorageService {
+  private static instance: SessionStorageService;
+
+  private constructor() {}
+
+  static getInstance(): SessionStorageService {
+    if (!SessionStorageService.instance) {
+      SessionStorageService.instance = new SessionStorageService();
+    }
+    return SessionStorageService.instance;
+  }
+
+  /**
+   * sessionStorageが利用可能かチェック
+   */
+  isAvailable(): boolean {
+    try {
+      if (typeof window === 'undefined' || !window.sessionStorage) {
+        return false;
+      }
+
+      // 書き込みテスト
+      const testKey = '__test__';
+      sessionStorage.setItem(testKey, 'test');
+      sessionStorage.removeItem(testKey);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * 現在の編集状態を保存
+   */
+  saveSession(checklist: Partial<ChecklistResult>): boolean {
+    if (!this.isAvailable()) {
+      return false;
+    }
+
+    try {
+      const sessionData: SessionData = {
+        title: checklist.title || '',
+        description: checklist.description || '',
+        notes: checklist.notes || '',
+        items: checklist.items || [],
+        judgment: checklist.judgment || null,
+        lastUpdated: new Date().toISOString()
+      };
+
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify(sessionData));
+      return true;
+    } catch (error) {
+      console.error('Failed to save session:', error);
+      return false;
+    }
+  }
+
+  /**
+   * 編集状態を復元
+   */
+  loadSession(): SessionData | null {
+    if (!this.isAvailable()) {
+      return null;
+    }
+
+    try {
+      const data = sessionStorage.getItem(SESSION_KEY);
+      if (!data) {
+        return null;
+      }
+
+      const sessionData = JSON.parse(data) as SessionData;
+
+      // 24時間以上経過したデータは無効
+      const lastUpdated = new Date(sessionData.lastUpdated);
+      const now = new Date();
+      const hoursDiff = (now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60);
+
+      if (hoursDiff > 24) {
+        this.clearSession();
+        return null;
+      }
+
+      return sessionData;
+    } catch (error) {
+      console.error('Failed to load session:', error);
+      return null;
+    }
+  }
+
+  /**
+   * セッションをクリア
+   */
+  clearSession(): void {
+    if (!this.isAvailable()) {
+      return;
+    }
+
+    try {
+      sessionStorage.removeItem(SESSION_KEY);
+    } catch (error) {
+      console.error('Failed to clear session:', error);
+    }
+  }
+
+  /**
+   * 言語設定のみ保存
+   */
+  saveLanguage(language: LanguageCode): void {
+    if (!this.isAvailable()) {
+      return;
+    }
+
+    try {
+      const currentSession = this.loadSession();
+      if (currentSession) {
+        currentSession.language = language;
+        sessionStorage.setItem(SESSION_KEY, JSON.stringify(currentSession));
+      }
+    } catch (error) {
+      console.error('Failed to save language:', error);
+    }
+  }
+}

--- a/src/lib/utils/uuid.ts
+++ b/src/lib/utils/uuid.ts
@@ -1,0 +1,47 @@
+/**
+ * UUID生成ユーティリティ
+ *
+ * crypto.randomUUID()を使用して標準準拠のUUIDを生成
+ * SSR環境でも動作するようにフォールバック実装を含む
+ */
+
+/**
+ * UUID v4を生成する
+ * @returns {string} UUID文字列（例：550e8400-e29b-41d4-a716-446655440000）
+ */
+export function generateUUID(): string {
+  // ブラウザ環境またはNode.js 16.7+でcrypto.randomUUID()が利用可能
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  // フォールバック実装（古い環境やSSR用）
+  // UUID v4の仕様に従った実装
+  const segments = [
+    Math.random().toString(16).substring(2, 10), // 8文字
+    Math.random().toString(16).substring(2, 6), // 4文字
+    `4${Math.random().toString(16).substring(2, 5)}`, // 4xxx（バージョン4）
+    ((Math.random() * 4) | 8).toString(16) + Math.random().toString(16).substring(2, 5), // yxxx（y = 8,9,a,b）
+    Math.random().toString(16).substring(2, 14) // 12文字
+  ];
+
+  return segments.join('-');
+}
+
+/**
+ * 短縮UUID（最初の8文字）を生成する
+ * URLなどで使用する場合に便利
+ * @returns {string} 短縮UUID文字列（例：550e8400）
+ */
+export function generateShortUUID(): string {
+  return generateUUID().split('-')[0] || '';
+}
+
+/**
+ * タイムスタンプベースのIDを生成する（レガシー互換用）
+ * @deprecated generateUUID()の使用を推奨
+ * @returns {string} タイムスタンプベースのID
+ */
+export function generateTimestampId(): string {
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}

--- a/src/routes/checklist/[id]/+page.svelte
+++ b/src/routes/checklist/[id]/+page.svelte
@@ -86,8 +86,14 @@
   }
 
   async function createNewChecklist() {
-    const id = await refactoredChecklistStore.createNewChecklist();
-    goto(`${base}/?id=${id}`);
+    // sessionStorageをクリアして新規作成
+    const sessionService = (
+      await import('$lib/services/SessionStorageService')
+    ).SessionStorageService.getInstance();
+    sessionService.clearSession();
+
+    // UUIDなしでホームに移動（セッション一時IDで作成される）
+    goto(`${base}/`);
   }
 
   function getJudgmentDisplay(judgment: JudgmentType) {


### PR DESCRIPTION
close #129 

⏺ Summary - Issue #129 対応完了

  Issue #129「UUID生成と、IndexedDB利用のタイミングを変更する」の実装が完了しました。

  実装内容：

  1. SessionStorageService作成 ✅
    - 編集状態を一時的に保存
    - 24時間の有効期限付き
    - 言語設定も保存可能
  2. UUID生成タイミングの変更 ✅
    - ホームページアクセス時：一時ID「session-temp」を使用
    - 評価完了時：正式なUUIDを生成
    - URLにはUUIDを表示しない（セッション中）
  3. SessionStorageでの編集状態保持 ✅
    - ページリロード時に編集内容を復元
    - 自動保存機能（デバウンス付き）
    - ルーティング時も状態を保持
  4. IndexedDB保存タイミングの変更 ✅
    - 編集中：SessionStorageに保存
    - 評価完了時：IndexedDBに保存
    - 完了後：SessionStorageをクリア
  5. 完了ページでのIndexedDB参照 ✅
    - 既存の実装で対応済み
    - /checklist/{uuid}?completed=trueでIndexedDBから読み込み

  主な変更点：

  - refactoredChecklistStore.svelte.ts:
    - createOrRestoreSession()メソッド追加
    - completeChecklist()でUUID生成
    - SessionStorage/IndexedDBの使い分け
  - +page.svelte:
    - startOrRestoreSession()に変更
    - 自動保存エフェクト追加
    - URLに一時IDを表示しない
  - SessionStorageService.ts:
    - 新規作成
    - 編集状態の保存/復元機能

  これにより、ユーザーは編集中にページを離れても内容を失わず、チェックリストの共有は評価完了
  後のみ可能となります。



