### PR TITLE
fix: Enable SSR translation loading

### DIFF
--- a/src/lib/i18n/store.svelte.ts
+++ b/src/lib/i18n/store.svelte.ts
@@ -70,10 +70,8 @@ class I18nStore {
   private _initialized = $state<boolean>(false);
 
   constructor() {
-    // ブラウザ環境では即座にデフォルト翻訳を読み込む
-    if (isBrowser) {
-      this.initializeImmediately();
-    }
+    // 即座にデフォルト翻訳を読み込む（SSRとブラウザ両方で）
+    this.initializeImmediately();
   }
 
   // 現在の言語（読み取り専用）
@@ -140,8 +138,10 @@ class I18nStore {
         this._translations[defaultLang] = allTranslations[defaultLang];
       }
 
-      // HTML属性を即座に更新
-      this.updateDocumentAttributes();
+      // HTML属性を即座に更新（ブラウザ環境のみ）
+      if (isBrowser) {
+        this.updateDocumentAttributes();
+      }
 
       // 初期化フラグを立てる
       this._initialized = true;


### PR DESCRIPTION
- Remove isBrowser check from constructor to load translations on server-side
- Make updateDocumentAttributes browser-only to prevent SSR errors
- This fixes the 'Translation not loaded' warnings during SSR